### PR TITLE
Change return type of renderHTML func in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function renderHTML(html) {
 
   var result = htmlAST.childNodes.map(renderNode);
 
-  return result.length === 1 ? result[0] : result;
+  return result;
 }
 
 module.exports = renderHTML;


### PR DESCRIPTION
When i worked on a project i used this library. I thought it would be a good idea that renderHTML function always returns an array even if it has only one element in the array, because i often find myself in situations where i needed to iterate over the elements of the array that renderHTML returns.